### PR TITLE
Fixed initial empty layers problem

### DIFF
--- a/src/main/js/bundles/dn_dynamiclegend/EsriLegendExtension.js
+++ b/src/main/js/bundles/dn_dynamiclegend/EsriLegendExtension.js
@@ -44,7 +44,7 @@ define([
         _createLegend: function () {
             var id = this.id;
             d_domStyle.set(this.domNode, "position", "relative");
-            createDomNode("div", {id: id + "_msg", innerHTML: this.NLS_creatingLegend + "..."}, this.domNode);
+            var msgNode = createDomNode("div", {id: id + "_msg", innerHTML: this.NLS_creatingLegend + "..."}, this.domNode);
 
             var hasWMSLegede = !1;
             var legendRequests = [];
@@ -85,7 +85,6 @@ define([
                 }
             }, this);
 
-            var msgNode = getDomNodeById(id + "_msg");
             if (legendRequests.length === 0 && !hasWMSLegede) {
                 msgNode && (msgNode.innerHTML = this.NLS_noLegend);
                 this._activate();

--- a/src/main/js/bundles/dn_dynamiclegend/manifest.json
+++ b/src/main/js/bundles/dn_dynamiclegend/manifest.json
@@ -1,6 +1,6 @@
 {
   "Bundle-SymbolicName": "dn_dynamiclegend",
-  "Bundle-Version": "1.0.1-SNAPSHOT",
+  "Bundle-Version": "1.0.2-SNAPSHOT",
   "Bundle-Name": "${bundleName}",
   "Bundle-Description": "${bundleDescription}",
   "Bundle-Vendor": "con terra GmbH",


### PR DESCRIPTION
The legend message domNode cannot be found in this case, to that the "creating legend..." label is not replaced by "no items..".